### PR TITLE
Fix elementFormDefault="qualified" regression

### DIFF
--- a/lib/savon/qualified_message.rb
+++ b/lib/savon/qualified_message.rb
@@ -27,7 +27,7 @@ module Savon
             translated_key  = translate_tag(key)
             newkey          = add_namespaces_to_values(key, path).first
             newpath         = path + [translated_key]
-            newhash[newkey] = to_hash(value, newpath)
+            newhash[newkey] = to_hash(value, @types[newpath] ? [@types[newpath]] : newpath)
           end
         end
         newhash


### PR DESCRIPTION
Types were not properly qualified

**What kind of change is this?**

Bugfix

**Did you add tests for your changes?**

I need some help writing the tests. The coverage of this area of code is minimal.

**Summary of changes**

This fixes the bug raised in #916. This means more recent versions of Savon do not work properly.

**Other information**
